### PR TITLE
Fix: Make all classes final and extract interfaces

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -12,7 +12,7 @@ namespace Refinery29\NewRelic;
 use Refinery29\NewRelic\Handler\DefaultHandler;
 use Refinery29\NewRelic\Handler\Handler;
 
-class Agent
+final class Agent implements AgentInterface
 {
     /**
      * @var Handler
@@ -24,12 +24,6 @@ class Agent
         $this->handler = $handler ?: new DefaultHandler();
     }
 
-    /**
-     * @param string $key
-     * @param mixed  $value
-     *
-     * @return mixed
-     */
     public function addCustomParameter($key, $value)
     {
         return $this->handle('newrelic_add_custom_parameter', [
@@ -38,11 +32,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param string $functionName
-     *
-     * @return mixed
-     */
     public function addCustomTracer($functionName)
     {
         return $this->handle('newrelic_add_custom_tracer', [
@@ -50,11 +39,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param bool $flag
-     *
-     * @return mixed
-     */
     public function backgroundJob($flag = true)
     {
         return $this->handle('newrelic_background_job', [
@@ -62,11 +46,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param bool $enable
-     *
-     * @return mixed
-     */
     public function captureParams($enable = true)
     {
         return $this->handle('newrelic_capture_params', [
@@ -74,12 +53,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param string $metricName
-     * @param mixed  $value
-     *
-     * @return mixed
-     */
     public function customMetric($metricName, $value)
     {
         return $this->handle('newrelic_custom_metric', [
@@ -88,27 +61,16 @@ class Agent
         ]);
     }
 
-    /**
-     * @return mixed
-     */
     public function disableAutoRum()
     {
         return $this->handle('newrelic_disable_autorum');
     }
 
-    /**
-     * @return mixed
-     */
     public function endOfTransaction()
     {
         return $this->handle('newrelic_end_of_transaction');
     }
 
-    /**
-     * @param bool $ignore
-     *
-     * @return mixed
-     */
     public function endTransaction($ignore = false)
     {
         return $this->handle('newrelic_end_transaction', [
@@ -116,11 +78,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param bool $includeTags
-     *
-     * @return mixed
-     */
     public function getBrowserTimingFooter($includeTags = false)
     {
         return $this->handle('newrelic_get_browser_timing_footer', [
@@ -128,11 +85,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param bool $includeTags
-     *
-     * @return mixed
-     */
     public function getBrowserTimingHeader($includeTags = false)
     {
         return $this->handle('newrelic_get_browser_timing_header', [
@@ -140,27 +92,16 @@ class Agent
         ]);
     }
 
-    /**
-     * @return mixed
-     */
     public function ignoreApdex()
     {
         return $this->handle('newrelic_ignore_apdex');
     }
 
-    /**
-     * @return mixed
-     */
     public function ignoreTransaction()
     {
         return $this->handle('newrelic_ignore_transaction');
     }
 
-    /**
-     * @param string $name
-     *
-     * @return mixed
-     */
     public function nameTransaction($name)
     {
         return $this->handle('newrelic_name_transaction', [
@@ -168,12 +109,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param string     $message
-     * @param \Exception $exception
-     *
-     * @return mixed
-     */
     public function noticeError($message, \Exception $exception = null)
     {
         return $this->handle('newrelic_notice_error', [
@@ -182,12 +117,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param string $name
-     * @param array  $attributes
-     *
-     * @return mixed
-     */
     public function recordCustomEvent($name, array $attributes)
     {
         return $this->handle('newrelic_record_custom_event', [
@@ -196,13 +125,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param string $name
-     * @param string $license
-     * @param bool   $xmit
-     *
-     * @return mixed
-     */
     public function setAppname($name, $license = '', $xmit = false)
     {
         return $this->handle('newrelic_set_appname', [
@@ -212,13 +134,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param string $user
-     * @param string $account
-     * @param string $product
-     *
-     * @return mixed
-     */
     public function setUserAttributes($user = '', $account = '', $product = '')
     {
         return $this->handle('newrelic_set_user_attributes', [
@@ -228,12 +143,6 @@ class Agent
         ]);
     }
 
-    /**
-     * @param string $appName
-     * @param string $license
-     *
-     * @return bool|mixed
-     */
     public function startTransaction($appName, $license = '')
     {
         return $this->handle('newrelic_start_transaction', [

--- a/src/AgentInterface.php
+++ b/src/AgentInterface.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\NewRelic;
+
+interface AgentInterface
+{
+    /**
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return mixed
+     */
+    public function addCustomParameter($key, $value);
+
+    /**
+     * @param string $functionName
+     *
+     * @return mixed
+     */
+    public function addCustomTracer($functionName);
+
+    /**
+     * @param bool $flag
+     *
+     * @return mixed
+     */
+    public function backgroundJob($flag = true);
+
+    /**
+     * @param bool $enable
+     *
+     * @return mixed
+     */
+    public function captureParams($enable = true);
+
+    /**
+     * @param string $metricName
+     * @param mixed  $value
+     *
+     * @return mixed
+     */
+    public function customMetric($metricName, $value);
+
+    /**
+     * @return mixed
+     */
+    public function disableAutoRum();
+
+    /**
+     * @return mixed
+     */
+    public function endOfTransaction();
+
+    /**
+     * @param bool $ignore
+     *
+     * @return mixed
+     */
+    public function endTransaction($ignore = false);
+
+    /**
+     * @param bool $includeTags
+     *
+     * @return mixed
+     */
+    public function getBrowserTimingFooter($includeTags = false);
+
+    /**
+     * @param bool $includeTags
+     *
+     * @return mixed
+     */
+    public function getBrowserTimingHeader($includeTags = false);
+
+    /**
+     * @return mixed
+     */
+    public function ignoreApdex();
+
+    /**
+     * @return mixed
+     */
+    public function ignoreTransaction();
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function nameTransaction($name);
+
+    /**
+     * @param string     $message
+     * @param \Exception $exception
+     *
+     * @return mixed
+     */
+    public function noticeError($message, \Exception $exception = null);
+
+    /**
+     * @param string $name
+     * @param array  $attributes
+     *
+     * @return mixed
+     */
+    public function recordCustomEvent($name, array $attributes);
+
+    /**
+     * @param string $name
+     * @param string $license
+     * @param bool   $xmit
+     *
+     * @return mixed
+     */
+    public function setAppname($name, $license = '', $xmit = false);
+
+    /**
+     * @param string $user
+     * @param string $account
+     * @param string $product
+     *
+     * @return mixed
+     */
+    public function setUserAttributes($user = '', $account = '', $product = '');
+
+    /**
+     * @param string $appName
+     * @param string $license
+     *
+     * @return bool|mixed
+     */
+    public function startTransaction($appName, $license = '');
+}

--- a/src/Handler/DefaultHandler.php
+++ b/src/Handler/DefaultHandler.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\NewRelic\Handler;
 
-class DefaultHandler implements Handler
+final class DefaultHandler implements Handler
 {
     public function handle($functionName, array $arguments = [])
     {

--- a/src/Handler/NullHandler.php
+++ b/src/Handler/NullHandler.php
@@ -9,7 +9,7 @@
 
 namespace Refinery29\NewRelic\Handler;
 
-class NullHandler implements Handler
+final class NullHandler implements Handler
 {
     public function handle($functionName, array $arguments = [])
     {

--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -10,10 +10,25 @@
 namespace Refinery29\NewRelic\Test;
 
 use Refinery29\NewRelic\Agent;
+use Refinery29\NewRelic\AgentInterface;
 use Refinery29\NewRelic\Handler;
 
 class AgentTest extends \PHPUnit_Framework_TestCase
 {
+    public function testIsFinal()
+    {
+        $reflection = new \ReflectionClass(Agent::class);
+
+        $this->assertTrue($reflection->isFinal());
+    }
+
+    public function testImplementsAgentInterface()
+    {
+        $reflection = new \ReflectionClass(Agent::class);
+
+        $this->assertTrue($reflection->implementsInterface(AgentInterface::class));
+    }
+
     public function testConstructCreatesHandler()
     {
         $agent = new Agent();

--- a/test/Handler/DefaultHandlerTest.php
+++ b/test/Handler/DefaultHandlerTest.php
@@ -11,14 +11,22 @@ namespace Refinery29\NewRelic\Test\Handler;
 
 use Refinery29\NewRelic\Handler\DefaultHandler;
 use Refinery29\NewRelic\Handler\Handler;
+use ReflectionClass;
 
 class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testImplementsInterface()
+    public function testIsFinal()
     {
-        $handler = new DefaultHandler();
+        $reflection = new ReflectionClass(DefaultHandler::class);
 
-        $this->assertInstanceOf(Handler::class, $handler);
+        $this->assertTrue($reflection->isFinal());
+    }
+
+    public function testImplementsHandlerInterface()
+    {
+        $reflection = new ReflectionClass(DefaultHandler::class);
+
+        $this->assertTrue($reflection->implementsInterface(Handler::class));
     }
 
     public function testHandleCallsFunctionWithArguments()

--- a/test/Handler/NullHandlerTest.php
+++ b/test/Handler/NullHandlerTest.php
@@ -11,14 +11,22 @@ namespace Refinery29\NewRelic\Test\Handler;
 
 use Refinery29\NewRelic\Handler\Handler;
 use Refinery29\NewRelic\Handler\NullHandler;
+use ReflectionClass;
 
 class NullHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testImplementsInterface()
+    public function testIsFinal()
     {
-        $handler = new NullHandler();
+        $reflection = new ReflectionClass(NullHandler::class);
 
-        $this->assertInstanceOf(Handler::class, $handler);
+        $this->assertTrue($reflection->isFinal());
+    }
+
+    public function testImplementsHandlerInterface()
+    {
+        $reflection = new ReflectionClass(NullHandler::class);
+
+        $this->assertTrue($reflection->implementsInterface(Handler::class));
     }
 
     public function testHandleReturnsFalse()


### PR DESCRIPTION
This PR

* [x] makes all classes `final` and extracts missing interfaces