### PR TITLE
Fix: Reject invalid arguments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.5 || ^7.0"
+        "php": "^5.5 || ^7.0",
+        "beberlei/assert": "^2.5.0"
     },
     "require-dev": {
         "codeclimate/php-test-reporter": "0.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,63 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "15d63cb345c8be76363bc8c8d496cf62",
-    "content-hash": "65e1c0ca7a0f35b18c3f3b8b8c94fc3b",
-    "packages": [],
+    "hash": "84140b113bc539aadb036adb8a4bcb04",
+    "content-hash": "d8437dca9b50395fdaddb789d4656530",
+    "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "91e2690c4ecc8a4e3e2d333430069f6a0c694a7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/91e2690c4ecc8a4e3e2d333430069f6a0c694a7a",
+                "reference": "91e2690c4ecc8a4e3e2d333430069f6a0c694a7a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "@stable"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Assert": "lib/"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2016-03-22 14:34:51"
+        }
+    ],
     "packages-dev": [
         {
             "name": "codeclimate/php-test-reporter",

--- a/src/Agent.php
+++ b/src/Agent.php
@@ -9,6 +9,7 @@
 
 namespace Refinery29\NewRelic;
 
+use Assert\Assertion;
 use Refinery29\NewRelic\Handler\DefaultHandler;
 use Refinery29\NewRelic\Handler\Handler;
 
@@ -26,6 +27,10 @@ final class Agent implements AgentInterface
 
     public function addCustomParameter($key, $value)
     {
+        Assertion::string($key);
+        Assertion::notBlank($key);
+        Assertion::scalar($value);
+
         return $this->handle('newrelic_add_custom_parameter', [
             $key,
             $value,
@@ -34,6 +39,9 @@ final class Agent implements AgentInterface
 
     public function addCustomTracer($functionName)
     {
+        Assertion::string($functionName);
+        Assertion::notBlank($functionName);
+
         return $this->handle('newrelic_add_custom_tracer', [
             $functionName,
         ]);
@@ -41,6 +49,8 @@ final class Agent implements AgentInterface
 
     public function backgroundJob($flag = true)
     {
+        Assertion::boolean($flag);
+
         $this->handle('newrelic_background_job', [
             $flag,
         ]);
@@ -48,6 +58,8 @@ final class Agent implements AgentInterface
 
     public function captureParams($enable = true)
     {
+        Assertion::boolean($enable);
+
         $this->handle('newrelic_capture_params', [
             $enable,
         ]);
@@ -55,6 +67,10 @@ final class Agent implements AgentInterface
 
     public function customMetric($metricName, $value)
     {
+        Assertion::string($metricName);
+        Assertion::notBlank($metricName);
+        Assertion::float($value);
+
         return $this->handle('newrelic_custom_metric', [
             $metricName,
             $value,
@@ -73,6 +89,8 @@ final class Agent implements AgentInterface
 
     public function endTransaction($ignore = false)
     {
+        Assertion::boolean($ignore);
+
         return $this->handle('newrelic_end_transaction', [
             $ignore,
         ]);
@@ -80,6 +98,8 @@ final class Agent implements AgentInterface
 
     public function getBrowserTimingFooter($includeTags = false)
     {
+        Assertion::boolean($includeTags);
+
         return $this->handle('newrelic_get_browser_timing_footer', [
             $includeTags,
         ]);
@@ -87,6 +107,8 @@ final class Agent implements AgentInterface
 
     public function getBrowserTimingHeader($includeTags = false)
     {
+        Assertion::boolean($includeTags);
+
         return $this->handle('newrelic_get_browser_timing_header', [
             $includeTags,
         ]);
@@ -104,6 +126,9 @@ final class Agent implements AgentInterface
 
     public function nameTransaction($name)
     {
+        Assertion::string($name);
+        Assertion::notBlank($name);
+
         return $this->handle('newrelic_name_transaction', [
             $name,
         ]);
@@ -111,6 +136,9 @@ final class Agent implements AgentInterface
 
     public function noticeError($message, \Exception $exception = null)
     {
+        Assertion::string($message);
+        Assertion::notBlank($message);
+
         $this->handle('newrelic_notice_error', [
             $message,
             $exception,
@@ -119,6 +147,11 @@ final class Agent implements AgentInterface
 
     public function recordCustomEvent($name, array $attributes)
     {
+        Assertion::string($name);
+        Assertion::notBlank($name);
+        Assertion::allString(array_keys($attributes));
+        Assertion::allScalar(array_values($attributes));
+
         $this->handle('newrelic_record_custom_event', [
             $name,
             $attributes,
@@ -127,6 +160,11 @@ final class Agent implements AgentInterface
 
     public function setAppname($name, $license = '', $xmit = false)
     {
+        Assertion::string($name);
+        Assertion::notBlank($name);
+        Assertion::string($license);
+        Assertion::boolean($xmit);
+
         return $this->handle('newrelic_set_appname', [
             $name,
             $license,
@@ -136,6 +174,10 @@ final class Agent implements AgentInterface
 
     public function setUserAttributes($user = '', $account = '', $product = '')
     {
+        Assertion::string($user);
+        Assertion::string($account);
+        Assertion::string($product);
+
         return $this->handle('newrelic_set_user_attributes', [
             $user,
             $account,
@@ -145,6 +187,10 @@ final class Agent implements AgentInterface
 
     public function startTransaction($appName, $license = '')
     {
+        Assertion::string($appName);
+        Assertion::notBlank($appName);
+        Assertion::string($license);
+
         return $this->handle('newrelic_start_transaction', [
             $appName,
             $license,

--- a/src/AgentInterface.php
+++ b/src/AgentInterface.php
@@ -36,6 +36,8 @@ interface AgentInterface
      * @param string                $key
      * @param string|int|float|bool $value
      *
+     * @throws \InvalidArgumentException
+     *
      * @return bool
      */
     public function addCustomParameter($key, $value);
@@ -64,6 +66,8 @@ interface AgentInterface
      * @link https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-newrelicini-settings#inivar-tt-custom
      *
      * @param bool $flag
+     *
+     * @throws \InvalidArgumentException
      */
     public function backgroundJob($flag = true);
 
@@ -79,6 +83,8 @@ interface AgentInterface
      * @link https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-newrelicini-settings#inivar-capture_params
      *
      * @param bool $enable
+     *
+     * @throws \InvalidArgumentException
      */
     public function captureParams($enable = true);
 
@@ -99,6 +105,8 @@ interface AgentInterface
      *
      * @param string $metricName
      * @param float  $value
+     *
+     * @throws \InvalidArgumentException
      *
      * @return bool
      */
@@ -145,6 +153,8 @@ interface AgentInterface
      *
      * @param bool $ignore
      *
+     * @throws \InvalidArgumentException
+     *
      * @return bool
      */
     public function endTransaction($ignore = false);
@@ -156,6 +166,8 @@ interface AgentInterface
      *
      * @param bool $includeTags
      *
+     * @throws \InvalidArgumentException
+     *
      * @return string
      */
     public function getBrowserTimingFooter($includeTags = false);
@@ -166,6 +178,8 @@ interface AgentInterface
      * enclosed in a <script> tag.
      *
      * @param bool $includeTags
+     *
+     * @throws \InvalidArgumentException
      *
      * @return string
      */
@@ -214,6 +228,8 @@ interface AgentInterface
 
      * @param string $name
      *
+     * @throws \InvalidArgumentException
+     *
      * @return bool
      */
     public function nameTransaction($name);
@@ -233,6 +249,8 @@ interface AgentInterface
      *
      * @param string     $message
      * @param \Exception $exception
+     *
+     * @throws \InvalidArgumentException
      */
     public function noticeError($message, \Exception $exception = null);
 
@@ -250,6 +268,8 @@ interface AgentInterface
      *
      * @param string $name
      * @param array  $attributes
+     *
+     * @throws \InvalidArgumentException
      */
     public function recordCustomEvent($name, array $attributes);
 
@@ -287,6 +307,8 @@ interface AgentInterface
      * @param string $license
      * @param bool   $xmit
      *
+     * @throws \InvalidArgumentException
+     *
      * @return bool
      */
     public function setAppname($name, $license = '', $xmit = false);
@@ -305,6 +327,8 @@ interface AgentInterface
      * @param string $account
      * @param string $product
      *
+     * @throws \InvalidArgumentException
+     *
      * @return bool
      */
     public function setUserAttributes($user = '', $account = '', $product = '');
@@ -322,6 +346,8 @@ interface AgentInterface
      *
      * @param string $appName
      * @param string $license
+     *
+     * @throws \InvalidArgumentException
      *
      * @return bool
      */

--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -49,6 +49,63 @@ class AgentTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $key
+     */
+    public function testAddCustomParameterRejectsInvalidKey($key)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $value = $this->getFaker()->randomNumber();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->addCustomParameter(
+            $key,
+            $value
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param string $key
+     */
+    public function testAddCustomParameterRejectsBlankKey($key)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $value = $this->getFaker()->randomNumber();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->addCustomParameter(
+            $key,
+            $value
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidScalar::data()
+     *
+     * @param mixed $value
+     */
+    public function testAddCustomParameterRejectsInvalidValue($value)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $key = $this->getFaker()->word;
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->addCustomParameter(
+            $key,
+            $value
+        );
+    }
+
+    /**
      * @dataProvider providerScalar
      *
      * @param mixed $value
@@ -96,6 +153,34 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $functionName
+     */
+    public function testAddCustomTracerRejectsInvalidFunctionName($functionName)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->addCustomTracer($functionName);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $functionName
+     */
+    public function testAddCustomTracerRejectsBlankFunctionName($functionName)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->addCustomTracer($functionName);
+    }
+
     public function testAddCustomTracer()
     {
         $faker = $this->getFaker();
@@ -117,6 +202,20 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($result, $agent->addCustomTracer($functionName));
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBoolean::data()
+     *
+     * @param mixed $flag
+     */
+    public function testBackgroundJobRejectsInvalidFlag($flag)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->backgroundJob($flag);
+    }
+
     public function testBackgroundJob()
     {
         $faker = $this->getFaker();
@@ -132,6 +231,20 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent->backgroundJob($flag);
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBoolean::data()
+     *
+     * @param mixed $enable
+     */
+    public function testCaptureParamsRejectsInvalidEnable($enable)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->captureParams($enable);
+    }
+
     public function testCaptureParams()
     {
         $faker = $this->getFaker();
@@ -145,6 +258,63 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent = new Agent($handler);
 
         $agent->captureParams($enable);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $metricName
+     */
+    public function testCustomMetricRejectsInvalidMetricName($metricName)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $value = $this->getFaker()->randomNumber();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->customMetric(
+            $metricName,
+            $value
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param string $metricName
+     */
+    public function testCustomMetricRejectsBlankMetricName($metricName)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $value = $this->getFaker()->randomNumber();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->customMetric(
+            $metricName,
+            $value
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidFloat::data()
+     *
+     * @param mixed $value
+     */
+    public function testCustomMetricRejectsInvalidValue($value)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $metricName = $this->getFaker()->word;
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->customMetric(
+            $metricName,
+            $value
+        );
     }
 
     public function testCustomMetric()
@@ -194,6 +364,20 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent->endOfTransaction();
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBoolean::data()
+     *
+     * @param mixed $ignore
+     */
+    public function testEndTransactionRejectsInvalidIgnore($ignore)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->endTransaction($ignore);
+    }
+
     public function testEndTransaction()
     {
         $ignore = $this->getFaker()->boolean();
@@ -205,6 +389,20 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent = new Agent($handler);
 
         $this->assertNull($agent->endTransaction($ignore));
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBoolean::data()
+     *
+     * @param mixed $includeTags
+     */
+    public function testGetBrowserTimingFooterRejectsInvalidIncludeTags($includeTags)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->getBrowserTimingFooter($includeTags);
     }
 
     public function testGetBrowserTimingFooter()
@@ -225,6 +423,20 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent = new Agent($handler);
 
         $this->assertSame($result, $agent->getBrowserTimingFooter($includeTags));
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBoolean::data()
+     *
+     * @param mixed $includeTags
+     */
+    public function testGetBrowserTimingHeaderRejectsInvalidIncludeTags($includeTags)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->getBrowserTimingHeader($includeTags);
     }
 
     public function testGetBrowserTimingHeader()
@@ -265,6 +477,34 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent->ignoreTransaction();
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $name
+     */
+    public function testNameTransactionRejectsInvalidName($name)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->nameTransaction($name);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $name
+     */
+    public function testNameTransactionRejectsBlankName($name)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->nameTransaction($name);
+    }
+
     public function testNameTransaction()
     {
         $faker = $this->getFaker();
@@ -286,6 +526,34 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($result, $agent->nameTransaction($name));
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $message
+     */
+    public function testNoticeErrorRejectsInvalidMessage($message)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->noticeError($message);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $message
+     */
+    public function testNoticeErrorRejectsBlankMessage($message)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->noticeError($message);
+    }
+
     public function testNoticeError()
     {
         $faker = $this->getFaker();
@@ -301,6 +569,97 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent = new Agent($handler);
 
         $agent->noticeError($message, $exception);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $name
+     */
+    public function testRecordCustomEventRejectsInvalidName($name)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $attributes = array_combine(
+            $faker->words(),
+            $faker->words()
+        );
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->recordCustomEvent(
+            $name,
+            $attributes
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $name
+     */
+    public function testRecordCustomEventRejectsBlankName($name)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $attributes = array_combine(
+            $faker->words(),
+            $faker->words()
+        );
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->recordCustomEvent(
+            $name,
+            $attributes
+        );
+    }
+
+    public function testRecordCustomEventRejectsNumericAttributeKeys()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $name = $faker->word;
+        $attributes = $faker->words();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->recordCustomEvent(
+            $name,
+            $attributes
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidScalar::data()
+     *
+     * @param mixed $value
+     */
+    public function testRecordCustomEventRejectsInvalidScalarAttributeValues($value)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $name = $faker->word;
+        $key = $faker->word;
+
+        $attributes = [
+            $key => $value,
+        ];
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->recordCustomEvent(
+            $name,
+            $attributes
+        );
     }
 
     public function testRecordCustomEvent()
@@ -321,6 +680,98 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent = new Agent($handler);
 
         $agent->recordCustomEvent($name, $attributes);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $name
+     */
+    public function testSetAppNameRejectsInvalidName($name)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $license = $faker->sentence();
+        $xmit = $faker->boolean();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->setAppname(
+            $name,
+            $license,
+            $xmit
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param string $name
+     */
+    public function testSetAppNameRejectsBlankName($name)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $license = $faker->sentence();
+        $xmit = $faker->boolean();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->setAppname(
+            $name,
+            $license,
+            $xmit
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param string $license
+     */
+    public function testSetAppNameRejectsInvalidLicense($license)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $name = $faker->word;
+        $xmit = $faker->boolean();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->setAppname(
+            $name,
+            $license,
+            $xmit
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidBoolean::data()
+     *
+     * @param mixed $xmit
+     */
+    public function testSetAppNameRejectsInvalidXmit($xmit)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $name = $faker->word;
+        $license = $faker->sentence();
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->setAppname(
+            $name,
+            $license,
+            $xmit
+        );
     }
 
     public function testSetAppName()
@@ -348,6 +799,62 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($result, $agent->setAppname($name, $licence, $xmit));
     }
 
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $user
+     */
+    public function testSetUserAttributesRejectsInvalidUser($user)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->setUserAttributes($user);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $account
+     */
+    public function testSetUserAttributesRejectsInvalidAccount($account)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $user = $this->getFaker()->word;
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->setUserAttributes(
+            $user,
+            $account
+        );
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $product
+     */
+    public function testSetUserAttributesRejectsInvalidProduct($product)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $faker = $this->getFaker();
+
+        $user = $faker->word;
+        $account = $faker->word;
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->setUserAttributes(
+            $user,
+            $account,
+            $product
+        );
+    }
+
     public function testSetUserAttributes()
     {
         $faker = $this->getFaker();
@@ -371,6 +878,53 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $agent = new Agent($handler);
 
         $this->assertSame($result, $agent->setUserAttributes($user, $account, $product));
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $appName
+     */
+    public function testStartTransactionRejectsInvalidAppName($appName)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->startTransaction($appName);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\BlankString::data()
+     *
+     * @param mixed $appName
+     */
+    public function testStartTransactionRejectsBlankAppName($appName)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->startTransaction($appName);
+    }
+
+    /**
+     * @dataProvider Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $license
+     */
+    public function testStartTransactionRejectsInvalidLicense($license)
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $appName = $this->getFaker()->word;
+
+        $agent = new Agent($this->getHandlerMock());
+
+        $agent->startTransaction(
+            $appName,
+            $license
+        );
     }
 
     public function testStartTransaction()


### PR DESCRIPTION
This PR

* [x] requires `beberlei/assert`
* [x] rejects invalid arguments
