### PR TITLE
Fix: Do not import classes from root namespace

### DIFF
--- a/test/Handler/DefaultHandlerTest.php
+++ b/test/Handler/DefaultHandlerTest.php
@@ -11,20 +11,19 @@ namespace Refinery29\NewRelic\Test\Handler;
 
 use Refinery29\NewRelic\Handler\DefaultHandler;
 use Refinery29\NewRelic\Handler\Handler;
-use ReflectionClass;
 
 class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
 {
     public function testIsFinal()
     {
-        $reflection = new ReflectionClass(DefaultHandler::class);
+        $reflection = new \ReflectionClass(DefaultHandler::class);
 
         $this->assertTrue($reflection->isFinal());
     }
 
     public function testImplementsHandlerInterface()
     {
-        $reflection = new ReflectionClass(DefaultHandler::class);
+        $reflection = new \ReflectionClass(DefaultHandler::class);
 
         $this->assertTrue($reflection->implementsInterface(Handler::class));
     }

--- a/test/Handler/NullHandlerTest.php
+++ b/test/Handler/NullHandlerTest.php
@@ -11,20 +11,19 @@ namespace Refinery29\NewRelic\Test\Handler;
 
 use Refinery29\NewRelic\Handler\Handler;
 use Refinery29\NewRelic\Handler\NullHandler;
-use ReflectionClass;
 
 class NullHandlerTest extends \PHPUnit_Framework_TestCase
 {
     public function testIsFinal()
     {
-        $reflection = new ReflectionClass(NullHandler::class);
+        $reflection = new \ReflectionClass(NullHandler::class);
 
         $this->assertTrue($reflection->isFinal());
     }
 
     public function testImplementsHandlerInterface()
     {
-        $reflection = new ReflectionClass(NullHandler::class);
+        $reflection = new \ReflectionClass(NullHandler::class);
 
         $this->assertTrue($reflection->implementsInterface(Handler::class));
     }


### PR DESCRIPTION
This PR

* [x] skips importing classes from the root namespace
