### PR TITLE
Fix: Case-insensitive method call

### DIFF
--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -381,7 +381,7 @@ class AgentTest extends \PHPUnit_Framework_TestCase
 
         $agent = new Agent($handler);
 
-        $this->assertSame($result, $agent->setAppName($name, $licence, $xmit));
+        $this->assertSame($result, $agent->setAppname($name, $licence, $xmit));
     }
 
     public function testSetUserAttributes()


### PR DESCRIPTION
This PR

* [x] fixes a case-insensitive method call
