### PR TITLE
Fix: Do not return anything

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -41,14 +41,14 @@ final class Agent implements AgentInterface
 
     public function backgroundJob($flag = true)
     {
-        return $this->handle('newrelic_background_job', [
+        $this->handle('newrelic_background_job', [
             $flag,
         ]);
     }
 
     public function captureParams($enable = true)
     {
-        return $this->handle('newrelic_capture_params', [
+        $this->handle('newrelic_capture_params', [
             $enable,
         ]);
     }
@@ -68,7 +68,7 @@ final class Agent implements AgentInterface
 
     public function endOfTransaction()
     {
-        return $this->handle('newrelic_end_of_transaction');
+        $this->handle('newrelic_end_of_transaction');
     }
 
     public function endTransaction($ignore = false)
@@ -94,12 +94,12 @@ final class Agent implements AgentInterface
 
     public function ignoreApdex()
     {
-        return $this->handle('newrelic_ignore_apdex');
+        $this->handle('newrelic_ignore_apdex');
     }
 
     public function ignoreTransaction()
     {
-        return $this->handle('newrelic_ignore_transaction');
+        $this->handle('newrelic_ignore_transaction');
     }
 
     public function nameTransaction($name)
@@ -111,7 +111,7 @@ final class Agent implements AgentInterface
 
     public function noticeError($message, \Exception $exception = null)
     {
-        return $this->handle('newrelic_notice_error', [
+        $this->handle('newrelic_notice_error', [
             $message,
             $exception,
         ]);
@@ -119,7 +119,7 @@ final class Agent implements AgentInterface
 
     public function recordCustomEvent($name, array $attributes)
     {
-        return $this->handle('newrelic_record_custom_event', [
+        $this->handle('newrelic_record_custom_event', [
             $name,
             $attributes,
         ]);

--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -123,19 +123,13 @@ class AgentTest extends \PHPUnit_Framework_TestCase
 
         $flag = $faker->boolean();
 
-        $result = $faker->boolean();
-
-        $handler = $this->getHandlerSpy(
-            'newrelic_background_job',
-            [
-                $flag,
-            ],
-            $result
-        );
+        $handler = $this->getHandlerSpy('newrelic_background_job', [
+            $flag,
+        ]);
 
         $agent = new Agent($handler);
 
-        $this->assertSame($result, $agent->backgroundJob($flag));
+        $agent->backgroundJob($flag);
     }
 
     public function testCaptureParams()
@@ -144,19 +138,13 @@ class AgentTest extends \PHPUnit_Framework_TestCase
 
         $enable = $faker->boolean();
 
-        $result = $faker->boolean();
-
-        $handler = $this->getHandlerSpy(
-            'newrelic_capture_params',
-            [
-                $enable,
-            ],
-            $result
-        );
+        $handler = $this->getHandlerSpy('newrelic_capture_params', [
+            $enable,
+        ]);
 
         $agent = new Agent($handler);
 
-        $this->assertSame($result, $agent->captureParams($enable));
+        $agent->captureParams($enable);
     }
 
     public function testCustomMetric()
@@ -199,26 +187,20 @@ class AgentTest extends \PHPUnit_Framework_TestCase
 
     public function testEndOfTransaction()
     {
-        $handler = $this->getHandlerSpy(
-            'newrelic_end_of_transaction',
-            []
-        );
+        $handler = $this->getHandlerSpy('newrelic_end_of_transaction');
 
         $agent = new Agent($handler);
 
-        $this->assertNull($agent->endOfTransaction());
+        $agent->endOfTransaction();
     }
 
     public function testEndTransaction()
     {
         $ignore = $this->getFaker()->boolean();
 
-        $handler = $this->getHandlerSpy(
-            'newrelic_end_transaction',
-            [
-                $ignore,
-            ]
-        );
+        $handler = $this->getHandlerSpy('newrelic_end_transaction', [
+            $ignore,
+        ]);
 
         $agent = new Agent($handler);
 
@@ -267,26 +249,20 @@ class AgentTest extends \PHPUnit_Framework_TestCase
 
     public function testIgnoreApdex()
     {
-        $handler = $this->getHandlerSpy(
-            'newrelic_ignore_apdex',
-            []
-        );
+        $handler = $this->getHandlerSpy('newrelic_ignore_apdex');
 
         $agent = new Agent($handler);
 
-        $this->assertNull($agent->ignoreApdex());
+        $agent->ignoreApdex();
     }
 
     public function testIgnoreTransaction()
     {
-        $handler = $this->getHandlerSpy(
-            'newrelic_ignore_transaction',
-            []
-        );
+        $handler = $this->getHandlerSpy('newrelic_ignore_transaction');
 
         $agent = new Agent($handler);
 
-        $this->assertNull($agent->ignoreTransaction());
+        $agent->ignoreTransaction();
     }
 
     public function testNameTransaction()
@@ -317,20 +293,14 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $message = $faker->sentence();
         $exception = new \InvalidArgumentException($faker->sentence());
 
-        $result = true;
-
-        $handler = $this->getHandlerSpy(
-            'newrelic_notice_error',
-            [
-                $message,
-                $exception,
-            ],
-            $result
-        );
+        $handler = $this->getHandlerSpy('newrelic_notice_error', [
+            $message,
+            $exception,
+        ]);
 
         $agent = new Agent($handler);
 
-        $this->assertSame($result, $agent->noticeError($message, $exception));
+        $agent->noticeError($message, $exception);
     }
 
     public function testRecordCustomEvent()
@@ -343,20 +313,14 @@ class AgentTest extends \PHPUnit_Framework_TestCase
             $faker->words()
         );
 
-        $result = $faker->boolean();
-
-        $handler = $this->getHandlerSpy(
-            'newrelic_record_custom_event',
-            [
-                $name,
-                $attributes,
-            ],
-            $result
-        );
+        $handler = $this->getHandlerSpy('newrelic_record_custom_event', [
+            $name,
+            $attributes,
+        ]);
 
         $agent = new Agent($handler);
 
-        $this->assertSame($result, $agent->recordCustomEvent($name, $attributes));
+        $agent->recordCustomEvent($name, $attributes);
     }
 
     public function testSetAppName()


### PR DESCRIPTION
This PR

* [x] adjusts the `Agent` to not return anything if nothing is supposed to be returned

Follos #38.
