### PR TITLE
Fix: Use all the columns

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,6 +6,7 @@
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     colors="true"
+    columns="max"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"


### PR DESCRIPTION
This PR

* [x] uses all the columns when running tests
