### PR TITLE
Fix: Keep attributes sorted in phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,10 @@
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.8/phpunit.xsd"
-    bootstrap="vendor/autoload.php"
     beStrictAboutChangesToGlobalState="true"
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
+    bootstrap="vendor/autoload.php"
     colors="true"
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"


### PR DESCRIPTION
This PR

* [x] keeps attributes in `phpunit.xml` sorted
