### PR TITLE
Fix: Use getMock()

### DIFF
--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -955,7 +955,7 @@ class AgentTest extends \PHPUnit_Framework_TestCase
      */
     private function getHandlerMock()
     {
-        return $this->getMockBuilder(Handler\Handler::class)->getMock();
+        return $this->getMock(Handler\Handler::class);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] uses `getMock()` instead of `getMockBuilder()->getMock()`
