### PR TITLE
Fix: Update refinery29/php-cs-fixer-config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require-dev": {
         "codeclimate/php-test-reporter": "0.3.2",
         "phpunit/phpunit": "^4.6.26",
-        "refinery29/php-cs-fixer-config": "0.4.16",
+        "refinery29/php-cs-fixer-config": "0.4.18",
         "refinery29/test-util": "0.4.3"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "71eee0f2373fa85a80bdeaca7a462477",
-    "content-hash": "3ae2ae3a911350b852bbadea0c0cb20b",
+    "hash": "1d4cdf25f2ff2a5c01acba66afe82aa4",
+    "content-hash": "f3f62f113421434c5e33e9246abc5c4d",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -896,16 +896,16 @@
         },
         {
             "name": "refinery29/php-cs-fixer-config",
-            "version": "0.4.16",
+            "version": "0.4.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/php-cs-fixer-config.git",
-                "reference": "7dd3a4117f69300ba1c7ef69e9738f1bc1fdb312"
+                "reference": "661f282db4f10f8b047c68e2309228d9c1b2241b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/7dd3a4117f69300ba1c7ef69e9738f1bc1fdb312",
-                "reference": "7dd3a4117f69300ba1c7ef69e9738f1bc1fdb312",
+                "url": "https://api.github.com/repos/refinery29/php-cs-fixer-config/zipball/661f282db4f10f8b047c68e2309228d9c1b2241b",
+                "reference": "661f282db4f10f8b047c68e2309228d9c1b2241b",
                 "shasum": ""
             },
             "require": {
@@ -913,8 +913,8 @@
                 "php": "^5.5 || ^7.0"
             },
             "require-dev": {
-                "codeclimate/php-test-reporter": "0.3.0",
-                "phpunit/phpunit": "^4.8.24"
+                "codeclimate/php-test-reporter": "0.3.2",
+                "phpunit/phpunit": "^4.8.26"
             },
             "type": "library",
             "autoload": {
@@ -933,7 +933,7 @@
                 }
             ],
             "description": "Provides a configuration for friendsofphp/php-cs-fixer, used within Refinery29.",
-            "time": "2016-05-31 13:24:02"
+            "time": "2016-07-14 09:57:54"
         },
         {
             "name": "refinery29/test-util",

--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -976,8 +976,7 @@ class AgentTest extends \PHPUnit_Framework_TestCase
                 $this->identicalTo($functionName),
                 $this->identicalTo($arguments)
             )
-            ->willReturn($result)
-        ;
+            ->willReturn($result);
 
         return $handler;
     }


### PR DESCRIPTION
This PR

* [x] updates `refinery29/php-cs-fixer-config`
* [x] runs `make cs`

💁 For reference, see https://github.com/refinery29/php-cs-fixer-config/compare/0.4.16...0.4.18.
