### PR TITLE
Enhancement: Report code coverage on pull request build, too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_install:
-  - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then IS_MERGE_TO_MASTER=true; else IS_MERGE_TO_MASTER=false; fi
-  - if [[ "$WITH_COVERAGE" != "true" && "$IS_MERGE_TO_MASTER" == "false" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
   - composer validate
   - composer config github-oauth.github.com $GITHUB_TOKEN
@@ -36,11 +35,11 @@ before_script:
   - mkdir -p build/logs
 
 script:
-  - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then vendor/bin/phpunit --configuration=phpunit.xml --coverage-clover=build/logs/clover.xml; else vendor/bin/phpunit --configuration=phpunit.xml; fi
+  - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/phpunit --configuration=phpunit.xml --coverage-clover=build/logs/clover.xml; else vendor/bin/phpunit --configuration=phpunit.xml; fi
   - if [[ "$WITH_CS" == "true" ]]; then vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run; fi
 
 after_success:
-  - if [[ "$WITH_COVERAGE" == "true" && "$IS_MERGE_TO_MASTER" == "true" ]]; then vendor/bin/test-reporter --coverage-report=build/logs/clover.xml; fi
+  - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/test-reporter --coverage-report=build/logs/clover.xml; fi
 
 notifications:
   email: false


### PR DESCRIPTION
This PR

* [x] also reports coverage on a pull request build

💁‍♂️ This allows us to show code coverage deltas as a status check in pull requests. As a heads up, this currently does not break the build if the code coverage declines. A source at Code Climate tells me they are working on it, but it will not automatically enabled.

For reference, see https://codeclimate.com/changelog/57bca9adb116ba032c0010b1.

### Before

![screen shot 2016-10-06 at 08 57 21](https://cloud.githubusercontent.com/assets/605483/19143252/ec89faf0-8ba2-11e6-922c-15078b35234f.png)

### After

![screen shot 2016-10-06 at 08 56 35](https://cloud.githubusercontent.com/assets/605483/19143242/df47b2ba-8ba2-11e6-9cb6-664e854d457c.png)