### PR TITLE
Fix: Remove HHVM from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
       env: WITH_CS=true
     - php: 7
       env: WITH_COVERAGE=true
-    - php: hhvm
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] drops HHVM from the build matrix
