### PR TITLE
Fix: Remove need to resolve global function in current namespace

### DIFF
--- a/src/Agent.php
+++ b/src/Agent.php
@@ -149,8 +149,8 @@ final class Agent implements AgentInterface
     {
         Assertion::string($name);
         Assertion::notBlank($name);
-        Assertion::allString(array_keys($attributes));
-        Assertion::allScalar(array_values($attributes));
+        Assertion::allString(\array_keys($attributes));
+        Assertion::allScalar(\array_values($attributes));
 
         $this->handle('newrelic_record_custom_event', [
             $name,

--- a/src/Handler/DefaultHandler.php
+++ b/src/Handler/DefaultHandler.php
@@ -13,7 +13,7 @@ final class DefaultHandler implements Handler
 {
     public function handle($functionName, array $arguments = [])
     {
-        return call_user_func_array($functionName, $arguments);
+        return \call_user_func_array($functionName, $arguments);
     }
 
     /**
@@ -21,6 +21,6 @@ final class DefaultHandler implements Handler
      */
     public function isExtensionLoaded()
     {
-        return extension_loaded('newrelic') && function_exists('newrelic_set_appname');
+        return \extension_loaded('newrelic') && function_exists('newrelic_set_appname');
     }
 }

--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -582,7 +582,7 @@ class AgentTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $attributes = array_combine(
+        $attributes = \array_combine(
             $faker->words(),
             $faker->words()
         );
@@ -606,7 +606,7 @@ class AgentTest extends \PHPUnit_Framework_TestCase
 
         $faker = $this->getFaker();
 
-        $attributes = array_combine(
+        $attributes = \array_combine(
             $faker->words(),
             $faker->words()
         );
@@ -667,7 +667,7 @@ class AgentTest extends \PHPUnit_Framework_TestCase
         $faker = $this->getFaker();
 
         $name = $faker->word;
-        $attributes = array_combine(
+        $attributes = \array_combine(
             $faker->words(),
             $faker->words()
         );

--- a/test/Handler/DefaultHandlerTest.php
+++ b/test/Handler/DefaultHandlerTest.php
@@ -39,7 +39,7 @@ class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
 
         $handler = new DefaultHandler();
 
-        $expected = call_user_func_array($functionName, $arguments);
+        $expected = \call_user_func_array($functionName, $arguments);
 
         $this->assertSame($expected, $handler->handle($functionName, $arguments));
     }
@@ -56,6 +56,6 @@ class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
      */
     private function isExtensionLoaded()
     {
-        return extension_loaded('newrelic') && function_exists('newrelic_set_appname');
+        return \extension_loaded('newrelic') && function_exists('newrelic_set_appname');
     }
 }


### PR DESCRIPTION
This PR

* [x] removes the need to look up global functions in current namespace

Follows https://github.com/refinery29/test-util/pull/126.

💁‍♂️ For reference, see 

* https://twitter.com/Ocramius/status/811504929357660160
* http://php.net/manual/en/language.namespaces.faq.php#language.namespaces.faq.shortname2
* http://veewee.github.io/blog/optimizing-php-performance-by-fq-function-calls/

>Function or constant names that do not contain a backslash like name can be resolved in 2 different ways.
>
>First, the current namespace name is prepended to _name_.
>
>Finally, if the constant or function _name_ does not exist in the current namespace, a global constant or function _name_ is used if it exists.