### PR TITLE
Enhancement: Update refinery29/test-util

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "codeclimate/php-test-reporter": "0.4.2",
         "phpunit/phpunit": "^5.7.7",
         "refinery29/php-cs-fixer-config": "0.6.9",
-        "refinery29/test-util": "0.4.3"
+        "refinery29/test-util": "0.10.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "374913affe7193904fb16783b90ad471",
+    "content-hash": "5f21ae166edad3ba768ae32e7b38cd20",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1228,30 +1228,28 @@
         },
         {
             "name": "refinery29/test-util",
-            "version": "0.4.3",
+            "version": "0.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/refinery29/test-util.git",
-                "reference": "a81600f3d51c85982e6980a0e6824acbfc0263f0"
+                "reference": "d5cb2abbf06ba4a70747aeadd8bc383200ae1f9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/test-util/zipball/a81600f3d51c85982e6980a0e6824acbfc0263f0",
-                "reference": "a81600f3d51c85982e6980a0e6824acbfc0263f0",
+                "url": "https://api.github.com/repos/refinery29/test-util/zipball/d5cb2abbf06ba4a70747aeadd8bc383200ae1f9b",
+                "reference": "d5cb2abbf06ba4a70747aeadd8bc383200ae1f9b",
                 "shasum": ""
             },
             "require": {
-                "fzaninotto/faker": "^1.6.0",
-                "php": ">=5.5"
+                "fzaninotto/faker": "^1.5.1",
+                "php": "^5.6 || ^7.0",
+                "phpunit/phpunit": "^5.2.0",
+                "zendframework/zend-file": "^2.7.1"
             },
             "require-dev": {
-                "beberlei/assert": "^2.5.0",
-                "codeclimate/php-test-reporter": "0.2.0",
-                "phpunit/phpunit": "^4.8.18 || ^5.2.3",
-                "refinery29/php-cs-fixer-config": "0.4.11"
-            },
-            "suggest": {
-                "phpunit/phpunit": "If you want to make use of the PHPUnit\\BuildsMocksTrait"
+                "beberlei/assert": "^2.7.1",
+                "codeclimate/php-test-reporter": "0.4.0",
+                "refinery29/php-cs-fixer-config": "0.6.7"
             },
             "type": "library",
             "autoload": {
@@ -1265,10 +1263,6 @@
             ],
             "authors": [
                 {
-                    "name": "Kayla Daniels",
-                    "email": "kayla.daniels@refinery29.com"
-                },
-                {
                     "name": "Andreas Möller",
                     "email": "andreas.moller@refinery29.com"
                 },
@@ -1277,13 +1271,13 @@
                     "email": "p.e@refinery29.com"
                 }
             ],
-            "description": "Provides helpers for testing.",
+            "description": "Provides a test helper, generic data providers, and assertions.",
             "keywords": [
                 "faker",
                 "test",
                 "util"
             ],
-            "time": "2016-05-15T20:56:52+00:00"
+            "time": "2017-01-11T17:36:55+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -2509,6 +2503,108 @@
                 "validate"
             ],
             "time": "2016-11-23T20:04:58+00:00"
+        },
+        {
+            "name": "zendframework/zend-file",
+            "version": "2.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-file.git",
+                "reference": "888fd4852432ee61ffd48a66b6812387b4f83c02"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-file/zipball/888fd4852432ee61ffd48a66b6812387b4f83c02",
+                "reference": "888fd4852432ee61ffd48a66b6812387b4f83c02",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-filter": "^2.6.1",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-progressbar": "^2.5.2",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-validator": "^2.6"
+            },
+            "suggest": {
+                "zendframework/zend-filter": "Zend\\Filter component",
+                "zendframework/zend-i18n": "Zend\\I18n component",
+                "zendframework/zend-validator": "Zend\\Validator component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\File\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-file",
+            "keywords": [
+                "file",
+                "zf2"
+            ],
+            "time": "2017-01-11T17:07:45+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "keywords": [
+                "stdlib",
+                "zf2"
+            ],
+            "time": "2016-09-13T14:38:50+00:00"
         }
     ],
     "aliases": [],

--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -12,11 +12,11 @@ namespace Refinery29\NewRelic\Test;
 use Refinery29\NewRelic\Agent;
 use Refinery29\NewRelic\AgentInterface;
 use Refinery29\NewRelic\Handler;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class AgentTest extends \PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {


### PR DESCRIPTION
This PR

* [x] updates `refinery29/test-util`
* [x] uses `TestHelper` instead of removed `GeneratorTrait`

💁‍♂️ For reference, see https://github.com/refinery29/test-util/compare/0.4.3...0.10.2.