### PR TITLE
Fix: Mark tests as final

### DIFF
--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -14,7 +14,7 @@ use Refinery29\NewRelic\AgentInterface;
 use Refinery29\NewRelic\Handler;
 use Refinery29\Test\Util\TestHelper;
 
-class AgentTest extends \PHPUnit_Framework_TestCase
+final class AgentTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 

--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -18,13 +18,6 @@ class AgentTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 
-    public function testIsFinal()
-    {
-        $reflection = new \ReflectionClass(Agent::class);
-
-        $this->assertTrue($reflection->isFinal());
-    }
-
     public function testImplementsAgentInterface()
     {
         $reflection = new \ReflectionClass(Agent::class);

--- a/test/Handler/DefaultHandlerTest.php
+++ b/test/Handler/DefaultHandlerTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\NewRelic\Test\Handler;
 use Refinery29\NewRelic\Handler\DefaultHandler;
 use Refinery29\NewRelic\Handler\Handler;
 
-class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
+final class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
 {
     public function testImplementsHandlerInterface()
     {

--- a/test/Handler/DefaultHandlerTest.php
+++ b/test/Handler/DefaultHandlerTest.php
@@ -14,13 +14,6 @@ use Refinery29\NewRelic\Handler\Handler;
 
 class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsFinal()
-    {
-        $reflection = new \ReflectionClass(DefaultHandler::class);
-
-        $this->assertTrue($reflection->isFinal());
-    }
-
     public function testImplementsHandlerInterface()
     {
         $reflection = new \ReflectionClass(DefaultHandler::class);

--- a/test/Handler/NullHandlerTest.php
+++ b/test/Handler/NullHandlerTest.php
@@ -14,13 +14,6 @@ use Refinery29\NewRelic\Handler\NullHandler;
 
 class NullHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsFinal()
-    {
-        $reflection = new \ReflectionClass(NullHandler::class);
-
-        $this->assertTrue($reflection->isFinal());
-    }
-
     public function testImplementsHandlerInterface()
     {
         $reflection = new \ReflectionClass(NullHandler::class);

--- a/test/Handler/NullHandlerTest.php
+++ b/test/Handler/NullHandlerTest.php
@@ -12,7 +12,7 @@ namespace Refinery29\NewRelic\Test\Handler;
 use Refinery29\NewRelic\Handler\Handler;
 use Refinery29\NewRelic\Handler\NullHandler;
 
-class NullHandlerTest extends \PHPUnit_Framework_TestCase
+final class NullHandlerTest extends \PHPUnit_Framework_TestCase
 {
     public function testImplementsHandlerInterface()
     {

--- a/test/ProjectCodeTest.php
+++ b/test/ProjectCodeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\NewRelic\Test;
+
+use Refinery29\Test\Util\TestHelper;
+
+final class ProjectCodeTest extends \PHPUnit_Framework_TestCase
+{
+    use TestHelper;
+
+    public function testTestCodeIsAbstractOrFinal()
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__);
+    }
+
+    public function testProjectCodeIsAbstractOrFinal()
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../src');
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that test and production classes are either `abstract` or `final`
* [x] marks tests as `final`

Follows #63.