### PR TITLE
Fix: Use assertions provided by TestHelper

### DIFF
--- a/test/AgentTest.php
+++ b/test/AgentTest.php
@@ -20,9 +20,7 @@ final class AgentTest extends \PHPUnit_Framework_TestCase
 
     public function testImplementsAgentInterface()
     {
-        $reflection = new \ReflectionClass(Agent::class);
-
-        $this->assertTrue($reflection->implementsInterface(AgentInterface::class));
+        $this->assertImplements(AgentInterface::class, Agent::class);
     }
 
     public function testConstructCreatesHandler()

--- a/test/Handler/DefaultHandlerTest.php
+++ b/test/Handler/DefaultHandlerTest.php
@@ -11,14 +11,15 @@ namespace Refinery29\NewRelic\Test\Handler;
 
 use Refinery29\NewRelic\Handler\DefaultHandler;
 use Refinery29\NewRelic\Handler\Handler;
+use Refinery29\Test\Util\TestHelper;
 
 final class DefaultHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    use TestHelper;
+
     public function testImplementsHandlerInterface()
     {
-        $reflection = new \ReflectionClass(DefaultHandler::class);
-
-        $this->assertTrue($reflection->implementsInterface(Handler::class));
+        $this->assertImplements(Handler::class, DefaultHandler::class);
     }
 
     public function testHandleCallsFunctionWithArguments()

--- a/test/Handler/NullHandlerTest.php
+++ b/test/Handler/NullHandlerTest.php
@@ -11,14 +11,15 @@ namespace Refinery29\NewRelic\Test\Handler;
 
 use Refinery29\NewRelic\Handler\Handler;
 use Refinery29\NewRelic\Handler\NullHandler;
+use Refinery29\Test\Util\TestHelper;
 
 final class NullHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    use TestHelper;
+
     public function testImplementsHandlerInterface()
     {
-        $reflection = new \ReflectionClass(NullHandler::class);
-
-        $this->assertTrue($reflection->implementsInterface(Handler::class));
+        $this->assertImplements(Handler::class, NullHandler::class);
     }
 
     public function testHandleReturnsFalse()


### PR DESCRIPTION
This PR

* [x] uses assertions as provided by `TestHelper`

Follows #63.