### PR TITLE
Add AgentAwareInterface and AgentAwareTrait

### DIFF
--- a/src/AgentAwareInterface.php
+++ b/src/AgentAwareInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\NewRelic;
+
+interface AgentAwareInterface
+{
+    public function setAgent(AgentInterface $agent);
+}

--- a/src/AgentAwareTrait.php
+++ b/src/AgentAwareTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Refinery29, Inc.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Refinery29\NewRelic;
+
+trait AgentAwareTrait
+{
+    /**
+     * @var AgentInterface
+     */
+    protected $agent;
+
+    public function setAgent(AgentInterface $agent)
+    {
+        $this->agent = $agent;
+    }
+}


### PR DESCRIPTION
* [x] add `AgentAwareInterface`
* [x] add `AgentAwareTrait`

The same idea as with `LoggerAwareInterface` and `LoggerAwareTrait`
https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#14-helper-classes-and-interfaces

> The Psr\Log\LoggerAwareInterface only contains a setLogger(LoggerInterface $logger) method and can be used by frameworks to auto-wire arbitrary instances with a logger.

> The Psr\Log\LoggerAwareTrait trait can be used to implement the equivalent interface easily in any class. It gives you access to $this->logger.